### PR TITLE
Utworzenie docker-compose dla jamFactory

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:latest
+    environment:
+      POSTGRES_DB: jam_factory
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: admin
+    ports:
+      - "5440:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "5051:80"
+    depends_on:
+      - postgres
+
+volumes:
+  postgres-data:

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.opentable.components</groupId>
+            <artifactId>otj-pg-embedded</artifactId>
+            <version>1.0.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=jamFactory

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,15 @@
+spring:
+  application:
+    name: jamFactory
+
+  datasource:
+    url: jdbc:postgresql://localhost:5440/jam_factory
+    username: postgres
+    password: admin
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/test/java/pl/akademiaspecjalistowit/jamfactory/JamFactoryApplicationTests.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jamfactory/JamFactoryApplicationTests.java
@@ -2,7 +2,9 @@ package pl.akademiaspecjalistowit.jamfactory;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class JamFactoryApplicationTests {
 

--- a/src/test/resourses/application-test.yaml
+++ b/src/test/resourses/application-test.yaml
@@ -1,0 +1,7 @@
+spring:
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: create-drop


### PR DESCRIPTION
1. Powstał plik docker-compose zawierający:
- postgress’a
- pgAdmin

2. application.yaml posiada konfigurację bazodanową aplikacji wskazującą na bazę z docker-compose’a