### PR TITLE
Dodanie do Open-API endpointu dla "Dodania planu produkcyjnego"

### DIFF
--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryController.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryController.java
@@ -1,0 +1,17 @@
+package pl.akademiaspecjalistowit.jamfactory.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import pl.akademiaspecjalistowit.jamfactory.dto.JamPlanProduktionRequestDto;
+
+@RestController
+@RequestMapping("/api/v1/jams")
+public class JamFactoryController {
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/product-plan")
+    public void addProductionPlan(@RequestBody JamPlanProduktionRequestDto jamPlanProduktionRequestDto) {
+        ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED);
+        }
+}

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryController.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryController.java
@@ -11,7 +11,7 @@ public class JamFactoryController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/product-plan")
-    public void addProductionPlan(@RequestBody JamPlanProduktionRequestDto jamPlanProduktionRequestDto) {
-        ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED);
-        }
+    public ResponseEntity<String> addProductionPlan(@RequestBody JamPlanProduktionRequestDto jamPlanProduktionRequestDto) {
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body("NOT_IMPLEMENTED");
+    }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryControllerAdvice.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryControllerAdvice.java
@@ -1,0 +1,29 @@
+package pl.akademiaspecjalistowit.jamfactory.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import pl.akademiaspecjalistowit.jamfactory.exception.JamFactoryException;
+
+@ControllerAdvice
+public class JamFactoryControllerAdvice {
+
+    @ExceptionHandler(JamFactoryException.class)
+    public ResponseEntity<RejectResponse> handleTravelException(JamFactoryException e) {
+        RejectResponse rejectResponse = new RejectResponse("przekraczajaca zdolnośc produkcyjna");
+        return new ResponseEntity<>(rejectResponse, HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RejectResponse {
+        private String rejectReason;
+    }
+}

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/dto/JamPlanProduktionRequestDto.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/dto/JamPlanProduktionRequestDto.java
@@ -1,0 +1,18 @@
+package pl.akademiaspecjalistowit.jamfactory.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Getter
+public class JamPlanProduktionRequestDto {
+    private LocalDate planDate;
+    private Integer smallJamJars;
+    private Integer mediumJamJars;
+    private Integer largeJamJars;
+}

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/exception/JamFactoryException.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/exception/JamFactoryException.java
@@ -1,0 +1,8 @@
+package pl.akademiaspecjalistowit.jamfactory.exception;
+
+public class JamFactoryException extends RuntimeException {
+
+    public JamFactoryException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/contract/openapi.yaml
+++ b/src/main/resources/contract/openapi.yaml
@@ -1,0 +1,77 @@
+openapi: 3.0.3
+info:
+  title: JamFactory API
+  version: 1.0.0
+  description: API for creating jam production plans at JamFactory
+
+servers:
+  - url: http://localhost:8080
+
+tags:
+  - name: ProductionPlans
+    description: Endpoints related to creating jam production plans.
+
+paths:
+  /jams/product-plan:
+    post:
+      tags:
+        - ProductionPlans
+      summary: Create a new jam production plan
+      operationId: createJamProductionPlan
+      requestBody:
+        description: Details of the production plan
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                planDate:
+                  type: string
+                  format: date
+                  example: "2024-09-01"
+                smallJamJars:
+                  type: integer
+                  example: 100
+                mediumJamJars:
+                  type: integer
+                  example: 50
+                largeJamJars:
+                  type: integer
+                  example: 20
+              required:
+                - planDate
+                - smallJamJars
+                - mediumJamJars
+                - largeJamJars
+      responses:
+        '201':
+          description: Production plan created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  planId:
+                    type: string
+                    example: "123e4567-e89b-12d3-a456-426614174000"
+        '422':
+          description: Business logic error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  rejectReason:
+                    type: string
+                    example: "przekraczająca zdolność produkcyjna"
+        '501':
+          description: Not Implemented
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Not Implemented"


### PR DESCRIPTION
1. Przygotowano plik openApi w formacie yaml posiadający endpoint POST /jams/product-plan w ramach JamFactory
Request posiada pola:
- planDate
- ilość małych słoików z dżemem
- ilość średnich słoików z dżemem
- ilość dużych słoików z dżemem

2. W przypadku utworzenia planu z sukcesem serwis odpowiada HTTP 201 created.

3. W przypadku błędu biznesowego odpowiadamy http XXX, a w body znajdue się example: { rejectReson: “przekraczajaca zdolnośc produkcyjna“}.

4. Wywołanie endpointa powinno skutkować zwórceniem notImplementedException.