### PR TITLE
013 dodanie do open api podgladu planu produkcyjnego

### DIFF
--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryController.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryController.java
@@ -14,4 +14,10 @@ public class JamFactoryController {
     public ResponseEntity<String> addProductionPlan(@RequestBody JamPlanProduktionRequestDto jamPlanProduktionRequestDto) {
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body("NOT_IMPLEMENTED");
     }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/product-plan")
+    public ResponseEntity<String> findProductionPlan(@RequestBody JamPlanProduktionRequestDto jamPlanProduktionRequestDto) {
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body("NOT_IMPLEMENTED");
+    }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryControllerAdvice.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryControllerAdvice.java
@@ -8,15 +8,22 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import pl.akademiaspecjalistowit.jamfactory.exception.JamFactoryException;
+import pl.akademiaspecjalistowit.jamfactory.exception.BusinessException;
+import pl.akademiaspecjalistowit.jamfactory.exception.ProductionException;
 
 @ControllerAdvice
 public class JamFactoryControllerAdvice {
 
-    @ExceptionHandler(JamFactoryException.class)
-    public ResponseEntity<RejectResponse> handleTravelException(JamFactoryException e) {
-        RejectResponse rejectResponse = new RejectResponse("przekraczajaca zdolnośc produkcyjna");
-        return new ResponseEntity<>(rejectResponse, HttpStatus.UNPROCESSABLE_ENTITY);
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<RejectResponse> handleTravelException(BusinessException e) {
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(new RejectResponse(e.getMessage(), ErrorCode.BUSINEES_ERROR));
+    }
+
+    @ExceptionHandler(ProductionException.class)
+    public ResponseEntity<RejectResponse> handleTravelException(ProductionException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new RejectResponse(e.getMessage(), ErrorCode.JAM_PRODUCTION_LIMIT_EXCEEDED));
     }
 
     @Getter
@@ -25,5 +32,11 @@ public class JamFactoryControllerAdvice {
     @NoArgsConstructor
     public static class RejectResponse {
         private String rejectReason;
+        private ErrorCode code;
+    }
+
+    enum ErrorCode {
+        BUSINEES_ERROR,
+        JAM_PRODUCTION_LIMIT_EXCEEDED
     }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/exception/BusinessException.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/exception/BusinessException.java
@@ -1,0 +1,8 @@
+package pl.akademiaspecjalistowit.jamfactory.exception;
+
+public class BusinessException extends RuntimeException {
+
+    public BusinessException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/exception/JamFactoryException.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/exception/JamFactoryException.java
@@ -1,8 +1,0 @@
-package pl.akademiaspecjalistowit.jamfactory.exception;
-
-public class JamFactoryException extends RuntimeException {
-
-    public JamFactoryException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/exception/ProductionException.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/exception/ProductionException.java
@@ -1,0 +1,8 @@
+package pl.akademiaspecjalistowit.jamfactory.exception;
+
+public class ProductionException extends RuntimeException {
+
+    public ProductionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/contract/openapi.yaml
+++ b/src/main/resources/contract/openapi.yaml
@@ -46,21 +46,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/NotImplementedError'
 
-  /jams/production-plan:
     get:
       tags:
         - ProductionPlans
-      summary: Get the current production plan
+      summary: Get the production plan overview for the next 7 days
       operationId: getProductionPlan
       responses:
         '200':
-          description: Production plan retrieved successfully
+          description: Production plan retrieved successfully for the next 7 days
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProductionPlanResponse'
+                $ref: '#/components/schemas/ProductionPlanOverviewResponse'
         '400':
-          description: Error adding production plan
+          description: Error retrieving the production plan
           content:
             application/json:
               schema:
@@ -120,3 +119,37 @@ components:
         error:
           type: string
           example: "Not Implemented"
+
+    ProductionPlanOverviewResponse:
+      type: object
+      properties:
+        perDay:
+          type: array
+          items:
+            type: object
+            properties:
+              date:
+                type: string
+                format: date
+                example: "2024-08-12"
+              M:
+                type: integer
+                example: 500
+              L:
+                type: integer
+                example: 300
+              S:
+                type: integer
+                example: 200
+        sum:
+          type: object
+          properties:
+            M:
+              type: integer
+              example: 1100
+            L:
+              type: integer
+              example: 900
+            S:
+              type: integer
+              example: 600

--- a/src/main/resources/contract/openapi.yaml
+++ b/src/main/resources/contract/openapi.yaml
@@ -6,7 +6,7 @@ info:
 
 servers:
   - url: http://localhost:8080/api/v1
-    description: Dev server
+    description: Jam server
 
 tags:
   - name: ProductionPlans
@@ -46,6 +46,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/NotImplementedError'
 
+  /jams/production-plan:
+    get:
+      tags:
+        - ProductionPlans
+      summary: Get the current production plan
+      operationId: getProductionPlan
+      responses:
+        '200':
+          description: Production plan retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductionPlanResponse'
+        '400':
+          description: Error adding production plan
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductionPlanErrorResponse'
+
 components:
   schemas:
     JamProductionPlanRequest:
@@ -83,6 +103,16 @@ components:
         rejectReason:
           type: string
           example: "przekraczająca zdolność produkcyjna"
+
+    ProductionPlanErrorResponse:
+      type: object
+      properties:
+        reason:
+          type: string
+          example: "Błąd dodania planu produkcyjnego - przekroczono XXXXXX"
+        code:
+          type: string
+          example: "JAM_DAILY_PRODUCTION_LIMIT_EXCEDED"
 
     NotImplementedError:
       type: object


### PR DESCRIPTION
- Dodano do open api w jamFactory endpoint HTTP GET /jams/product-plan
- Endpoint zwraca HTTP 200 ze strukturą zgodna z zadania “Podgląd planu produkcyjnego (JamFactory)- implementacja”
- Endpoint w przypadku błędu dodania planu produkcyjnego zwraca HTTP 400 ze strukturą np.

{
  reason: "Błąd dodania planu produkcyjnego - przekroczono XXXXXX",
  code: "JAM_DAILY_PRODUCTION_LIMIT_EXCEDED"
}

- Zaktualizować testy oraz implementację do tego API.