### PR TITLE
008 Dodanie planu produkcyjnego uwzglednienie mozliwosci transportowych

### DIFF
--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/configuration/ApiProperties.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/configuration/ApiProperties.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 
 @Getter
 @Setter
-@ConfigurationProperties(prefix = "max-delivery-capacity")
+@ConfigurationProperties(prefix = "limits")
 @Component
 public class ApiProperties {
     private Integer maxDeliveryCapacity;

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/configuration/ApiProperties.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/configuration/ApiProperties.java
@@ -5,8 +5,6 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-
-
 @Getter
 @Setter
 @ConfigurationProperties(prefix = "max-delivery-capacity")

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/configuration/ApiProperties.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/configuration/ApiProperties.java
@@ -1,0 +1,16 @@
+package pl.akademiaspecjalistowit.jamfactory.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "max-delivery-capacity")
+@Component
+public class ApiProperties {
+    private Integer maxDeliveryCapacity;
+}

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryController.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryController.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import pl.akademiaspecjalistowit.jamfactory.dto.*;
+import pl.akademiaspecjalistowit.jamfactory.dto.JamPlanProductionRequestDto;
 import pl.akademiaspecjalistowit.jamfactory.service.JamPlanProductionService;
 
 import java.util.UUID;

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryController.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryController.java
@@ -2,6 +2,7 @@ package pl.akademiaspecjalistowit.jamfactory.controller;
 
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import pl.akademiaspecjalistowit.jamfactory.dto.*;
 import pl.akademiaspecjalistowit.jamfactory.service.JamPlanProductionService;
@@ -22,7 +23,7 @@ public class JamFactoryController {
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/product-plan")
-    public ResponseEntity<String> findProductionPlan(@RequestBody JamPlanProduktionRequestDto jamPlanProduktionRequestDto) {
+    public ResponseEntity<String> findProductionPlan(@RequestBody JamPlanProductionRequestDto jamPlanProductionRequestDto) {
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body("NOT_IMPLEMENTED");
     }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryControllerAdvice.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryControllerAdvice.java
@@ -37,6 +37,6 @@ public class JamFactoryControllerAdvice {
 
     enum ErrorCode {
         BUSINESS_ERROR,
-        JAM_PRODUCTION_LIMIT_EXCEEDED
+        JAM_PRODUCTION_LIMIT_EXCEEDED,
     }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryControllerAdvice.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryControllerAdvice.java
@@ -17,7 +17,7 @@ public class JamFactoryControllerAdvice {
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<RejectResponse> handleTravelException(BusinessException e) {
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
-                .body(new RejectResponse(e.getMessage(), ErrorCode.BUSINEES_ERROR));
+                .body(new RejectResponse(e.getMessage(), ErrorCode.BUSINESS_ERROR));
     }
 
     @ExceptionHandler(ProductionException.class)
@@ -36,7 +36,7 @@ public class JamFactoryControllerAdvice {
     }
 
     enum ErrorCode {
-        BUSINEES_ERROR,
+        BUSINESS_ERROR,
         JAM_PRODUCTION_LIMIT_EXCEEDED
     }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/entity/JamPlanProductionEntity.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/entity/JamPlanProductionEntity.java
@@ -1,4 +1,4 @@
-package pl.akademiaspecjalistowit.jamfactory;
+package pl.akademiaspecjalistowit.jamfactory.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/mapper/JamsMapper.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/mapper/JamsMapper.java
@@ -1,7 +1,7 @@
 package pl.akademiaspecjalistowit.jamfactory.mapper;
 
 import org.springframework.stereotype.Component;
-import pl.akademiaspecjalistowit.jamfactory.JamPlanProductionEntity;
+import pl.akademiaspecjalistowit.jamfactory.entity.JamPlanProductionEntity;
 import pl.akademiaspecjalistowit.jamfactory.dto.JamPlanProductionRequestDto;
 
 @Component

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/repositories/JamPlanProductionRepository.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/repositories/JamPlanProductionRepository.java
@@ -2,7 +2,7 @@ package pl.akademiaspecjalistowit.jamfactory.repositories;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import pl.akademiaspecjalistowit.jamfactory.JamPlanProductionEntity;
+import pl.akademiaspecjalistowit.jamfactory.entity.JamPlanProductionEntity;
 
 @Repository
 public interface JamPlanProductionRepository extends JpaRepository<JamPlanProductionEntity, Long> {

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionService.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionService.java
@@ -2,8 +2,11 @@ package pl.akademiaspecjalistowit.jamfactory.service;
 
 import pl.akademiaspecjalistowit.jamfactory.dto.JamPlanProductionRequestDto;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 public interface JamPlanProductionService {
+
     UUID addProductionPlan(JamPlanProductionRequestDto jamPlanProductionRequestDto);
 }

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImpl.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImpl.java
@@ -2,6 +2,7 @@ package pl.akademiaspecjalistowit.jamfactory.service;
 
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import pl.akademiaspecjalistowit.jamfactory.configuration.ApiProperties;
 import pl.akademiaspecjalistowit.jamfactory.dto.JamPlanProductionRequestDto;
 import pl.akademiaspecjalistowit.jamfactory.entity.JamPlanProductionEntity;
 import pl.akademiaspecjalistowit.jamfactory.exception.ProductionException;
@@ -17,6 +18,7 @@ import java.util.UUID;
 public class JamPlanProductionServiceImpl implements JamPlanProductionService {
     private final JamPlanProductionRepository jamPlanProductionRepository;
     private final JamsMapper jamsMapper;
+    private final ApiProperties apiProperties;
 
     @Override
     public UUID addProductionPlan(JamPlanProductionRequestDto jamPlanProductionRequestDto) {
@@ -27,25 +29,88 @@ public class JamPlanProductionServiceImpl implements JamPlanProductionService {
     }
 
 //    Dodanie nowego Planu produkcyjnego jest możliwe jeżeli:
-//    w ramach jednego dnia ilość dostarczonych słoików (wynikająca z istnejącego dziennego planu produkcyjnych) nie można być większa niż X.
-//            (Ilość dni x maxDeliveryCapacity - aktualne plany produkcyjne) >= nowy plan
+
+//    w ramach jednego dnia ilość dostarczonych słoików (wynikająca z istnejącego dziennego planu produkcyjnych)
+//    nie można być większa niż X.
+
+//    (Ilość dni x maxDeliveryCapacity - aktualne plany produkcyjne) >= nowy plan
+
 //    X jest elementem parametryzowanym w application.yaml
+
 //    MaxDeliveryCapacity: 15 000
 
     private void validateProductionPlan(JamPlanProductionRequestDto jamPlanProductionRequestDto) {
-        LocalDate planDate = jamPlanProductionRequestDto.getPlanDate();
-        Integer newPlanTotalJars = jamPlanProductionRequestDto.getSmallJamJars() + jamPlanProductionRequestDto.getMediumJamJars() + jamPlanProductionRequestDto.getLargeJamJars();
+        LocalDate today = LocalDate.now();
+        LocalDate plannedPlanDate = jamPlanProductionRequestDto.getPlanDate();
+        Integer maxDeliveryCapacityPerDay = apiProperties.getMaxDeliveryCapacity();
 
-        // Получаем текущие производственные планы на указанный день
-        List<JamPlanProductionEntity> existingPlans = jamPlanProductionRepository.findAll();
-        Integer existingJarsForTheDay = existingPlans.stream()
-                .filter(plan -> plan.getPlanDate().equals(planDate))
+        Integer totalJamJarsForPlannedDay = jamPlanProductionRequestDto.getSmallJamJars() +
+                jamPlanProductionRequestDto.getMediumJamJars() +
+                jamPlanProductionRequestDto.getLargeJamJars();
+
+        if (totalJamJarsForPlannedDay > maxDeliveryCapacityPerDay) {
+
+            List<JamPlanProductionEntity> planProductionBeforePlannedPlanDate = jamPlanProductionRepository.findAll().stream()
+                    .filter(plan -> plan.getPlanDate().isBefore(plannedPlanDate))
+                    .toList();
+
+            Integer existingSumJarsBeforePlanDay = jamPlanProductionRepository.findAll().stream()
+                    .filter(plan -> !plan.getPlanDate().isBefore(today) && !plan.getPlanDate().isAfter(plannedPlanDate))
+                    .mapToInt(plan -> plan.getSmallJamJars() + plan.getMediumJamJars() + plan.getLargeJamJars())
+                    .sum();
+
+            Long daysInRange = planProductionBeforePlannedPlanDate.stream()
+                    .filter(plan -> plan.getPlanDate().isBefore(today))
+                    .count();
+
+            long maxCapacityInRange = daysInRange * maxDeliveryCapacityPerDay;
+
+            long availableSpace = maxCapacityInRange - existingSumJarsBeforePlanDay;
+
+            if (totalJamJarsForPlannedDay > availableSpace) {
+                throw new ProductionException("Przekroczono zdolność transportową. Dostępne miejsce tylko na " + availableSpace + " słoików.");
+            }
+            throw new ProductionException("Przekroczono dzienną zdolność transportową. Spróbuj rozdzielić na wcześniejsze dniю");
+        }
+    }
+
+    private void validateProductionPlan2(JamPlanProductionRequestDto jamPlanProductionRequestDto) {
+        LocalDate today = LocalDate.now();
+
+        LocalDate plannedPlanDate = jamPlanProductionRequestDto.getPlanDate();
+
+        Integer maxDeliveryCapacityPerDay = apiProperties.getMaxDeliveryCapacity();
+
+        Integer totalJamJarsForPlannedDay = jamPlanProductionRequestDto.getSmallJamJars() +
+                jamPlanProductionRequestDto.getMediumJamJars() +
+                jamPlanProductionRequestDto.getLargeJamJars();
+
+        Integer moreThanMaxDeliveryCapacityPerDay = totalJamJarsForPlannedDay - maxDeliveryCapacityPerDay;
+
+        List<JamPlanProductionEntity> planProductionBeforePlannedPlanDate = jamPlanProductionRepository.findAll().stream()
+                .filter(plan -> plan.getPlanDate().isBefore(plannedPlanDate))
+                .toList();
+
+        Integer existingSumJarsBeforePlanDay = jamPlanProductionRepository.findAll().stream()
+                .filter(plan -> !plan.getPlanDate().isBefore(today) && !plan.getPlanDate().isAfter(plannedPlanDate))
                 .mapToInt(plan -> plan.getSmallJamJars() + plan.getMediumJamJars() + plan.getLargeJamJars())
                 .sum();
 
-        // Проверка на превышение максимальной вместимости
-        if (existingJarsForTheDay + newPlanTotalJars > apiProperties.getMaxDeliveryCapacity()) {
-            throw new ProductionException("Превышен лимит на количество банок для данного дня");
+        Long countDaysBeforePlanDay = planProductionBeforePlannedPlanDate.stream()
+                .filter(plan -> plan.getPlanDate().isBefore(today))
+                .count();
+
+        Long maxDeliveryCapacityBeforePlanDay = countDaysBeforePlanDay * maxDeliveryCapacityPerDay;
+
+        long howManyPlaceWeHave = maxDeliveryCapacityBeforePlanDay - existingSumJarsBeforePlanDay;
+
+        long more = howManyPlaceWeHave - moreThanMaxDeliveryCapacityPerDay;
+
+        if (totalJamJarsForPlannedDay > maxDeliveryCapacityPerDay) {
+            if (moreThanMaxDeliveryCapacityPerDay > howManyPlaceWeHave) {
+                throw new ProductionException("przekraczajaca zdolnośc transportowa. Mamy mejsce tylko na " + more);
+            }
+            throw new ProductionException("przekraczajaca zdolnośc transportowa. Mozna przelogyc na poprzedni dni");
         }
     }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImpl.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImpl.java
@@ -2,11 +2,14 @@ package pl.akademiaspecjalistowit.jamfactory.service;
 
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
-import pl.akademiaspecjalistowit.jamfactory.JamPlanProductionEntity;
 import pl.akademiaspecjalistowit.jamfactory.dto.JamPlanProductionRequestDto;
+import pl.akademiaspecjalistowit.jamfactory.entity.JamPlanProductionEntity;
+import pl.akademiaspecjalistowit.jamfactory.exception.ProductionException;
 import pl.akademiaspecjalistowit.jamfactory.mapper.JamsMapper;
 import pl.akademiaspecjalistowit.jamfactory.repositories.JamPlanProductionRepository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 @AllArgsConstructor
@@ -18,8 +21,31 @@ public class JamPlanProductionServiceImpl implements JamPlanProductionService {
     @Override
     public UUID addProductionPlan(JamPlanProductionRequestDto jamPlanProductionRequestDto) {
         JamPlanProductionEntity entity = jamsMapper.toEntity(jamPlanProductionRequestDto);
-
+        validateProductionPlan(jamPlanProductionRequestDto);
         jamPlanProductionRepository.save(entity);
         return entity.getPlanId();
+    }
+
+//    Dodanie nowego Planu produkcyjnego jest możliwe jeżeli:
+//    w ramach jednego dnia ilość dostarczonych słoików (wynikająca z istnejącego dziennego planu produkcyjnych) nie można być większa niż X.
+//            (Ilość dni x maxDeliveryCapacity - aktualne plany produkcyjne) >= nowy plan
+//    X jest elementem parametryzowanym w application.yaml
+//    MaxDeliveryCapacity: 15 000
+
+    private void validateProductionPlan(JamPlanProductionRequestDto jamPlanProductionRequestDto) {
+        LocalDate planDate = jamPlanProductionRequestDto.getPlanDate();
+        Integer newPlanTotalJars = jamPlanProductionRequestDto.getSmallJamJars() + jamPlanProductionRequestDto.getMediumJamJars() + jamPlanProductionRequestDto.getLargeJamJars();
+
+        // Получаем текущие производственные планы на указанный день
+        List<JamPlanProductionEntity> existingPlans = jamPlanProductionRepository.findAll();
+        Integer existingJarsForTheDay = existingPlans.stream()
+                .filter(plan -> plan.getPlanDate().equals(planDate))
+                .mapToInt(plan -> plan.getSmallJamJars() + plan.getMediumJamJars() + plan.getLargeJamJars())
+                .sum();
+
+        // Проверка на превышение максимальной вместимости
+        if (existingJarsForTheDay + newPlanTotalJars > apiProperties.getMaxDeliveryCapacity()) {
+            throw new ProductionException("Превышен лимит на количество банок для данного дня");
+        }
     }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImpl.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImpl.java
@@ -18,6 +18,7 @@ public class JamPlanProductionServiceImpl implements JamPlanProductionService {
     @Override
     public UUID addProductionPlan(JamPlanProductionRequestDto jamPlanProductionRequestDto) {
         JamPlanProductionEntity entity = jamsMapper.toEntity(jamPlanProductionRequestDto);
+
         jamPlanProductionRepository.save(entity);
         return entity.getPlanId();
     }

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImpl.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImpl.java
@@ -1,5 +1,6 @@
 package pl.akademiaspecjalistowit.jamfactory.service;
 
+import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import pl.akademiaspecjalistowit.jamfactory.configuration.ApiProperties;
@@ -9,6 +10,7 @@ import pl.akademiaspecjalistowit.jamfactory.exception.ProductionException;
 import pl.akademiaspecjalistowit.jamfactory.mapper.JamsMapper;
 import pl.akademiaspecjalistowit.jamfactory.repositories.JamPlanProductionRepository;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -20,98 +22,52 @@ public class JamPlanProductionServiceImpl implements JamPlanProductionService {
     private final JamsMapper jamsMapper;
     private final ApiProperties apiProperties;
 
+    @Transactional
     @Override
     public UUID addProductionPlan(JamPlanProductionRequestDto jamPlanProductionRequestDto) {
-        JamPlanProductionEntity entity = jamsMapper.toEntity(jamPlanProductionRequestDto);
         validateProductionPlan(jamPlanProductionRequestDto);
+        JamPlanProductionEntity entity = jamsMapper.toEntity(jamPlanProductionRequestDto);
         jamPlanProductionRepository.save(entity);
         return entity.getPlanId();
     }
 
-//    Dodanie nowego Planu produkcyjnego jest możliwe jeżeli:
-
-//    w ramach jednego dnia ilość dostarczonych słoików (wynikająca z istnejącego dziennego planu produkcyjnych)
-//    nie można być większa niż X.
-
-//    (Ilość dni x maxDeliveryCapacity - aktualne plany produkcyjne) >= nowy plan
-
-//    X jest elementem parametryzowanym w application.yaml
-
-//    MaxDeliveryCapacity: 15 000
-
     private void validateProductionPlan(JamPlanProductionRequestDto jamPlanProductionRequestDto) {
         LocalDate today = LocalDate.now();
         LocalDate plannedPlanDate = jamPlanProductionRequestDto.getPlanDate();
+        LocalDate checkUntilDate;
         Integer maxDeliveryCapacityPerDay = apiProperties.getMaxDeliveryCapacity();
 
         Integer totalJamJarsForPlannedDay = jamPlanProductionRequestDto.getSmallJamJars() +
                 jamPlanProductionRequestDto.getMediumJamJars() +
                 jamPlanProductionRequestDto.getLargeJamJars();
 
-        if (totalJamJarsForPlannedDay > maxDeliveryCapacityPerDay) {
+        List<JamPlanProductionEntity> existingPlans = jamPlanProductionRepository.findAll();
 
-            List<JamPlanProductionEntity> planProductionBeforePlannedPlanDate = jamPlanProductionRepository.findAll().stream()
-                    .filter(plan -> plan.getPlanDate().isBefore(plannedPlanDate))
-                    .toList();
+        LocalDate latestPlanDate = existingPlans.stream()
+                .map(JamPlanProductionEntity::getPlanDate)
+                .max(LocalDate::compareTo)
+                .orElse(plannedPlanDate);
 
-            Integer existingSumJarsBeforePlanDay = jamPlanProductionRepository.findAll().stream()
-                    .filter(plan -> !plan.getPlanDate().isBefore(today) && !plan.getPlanDate().isAfter(plannedPlanDate))
-                    .mapToInt(plan -> plan.getSmallJamJars() + plan.getMediumJamJars() + plan.getLargeJamJars())
-                    .sum();
-
-            Long daysInRange = planProductionBeforePlannedPlanDate.stream()
-                    .filter(plan -> plan.getPlanDate().isBefore(today))
-                    .count();
-
-            long maxCapacityInRange = daysInRange * maxDeliveryCapacityPerDay;
-
-            long availableSpace = maxCapacityInRange - existingSumJarsBeforePlanDay;
-
-            if (totalJamJarsForPlannedDay > availableSpace) {
-                throw new ProductionException("Przekroczono zdolność transportową. Dostępne miejsce tylko na " + availableSpace + " słoików.");
-            }
-            throw new ProductionException("Przekroczono dzienną zdolność transportową. Spróbuj rozdzielić na wcześniejsze dniю");
+        if (plannedPlanDate.isAfter(latestPlanDate)) {
+            checkUntilDate = plannedPlanDate;
+        } else {
+            checkUntilDate = latestPlanDate;
         }
-    }
 
-    private void validateProductionPlan2(JamPlanProductionRequestDto jamPlanProductionRequestDto) {
-        LocalDate today = LocalDate.now();
-
-        LocalDate plannedPlanDate = jamPlanProductionRequestDto.getPlanDate();
-
-        Integer maxDeliveryCapacityPerDay = apiProperties.getMaxDeliveryCapacity();
-
-        Integer totalJamJarsForPlannedDay = jamPlanProductionRequestDto.getSmallJamJars() +
-                jamPlanProductionRequestDto.getMediumJamJars() +
-                jamPlanProductionRequestDto.getLargeJamJars();
-
-        Integer moreThanMaxDeliveryCapacityPerDay = totalJamJarsForPlannedDay - maxDeliveryCapacityPerDay;
-
-        List<JamPlanProductionEntity> planProductionBeforePlannedPlanDate = jamPlanProductionRepository.findAll().stream()
-                .filter(plan -> plan.getPlanDate().isBefore(plannedPlanDate))
-                .toList();
-
-        Integer existingSumJarsBeforePlanDay = jamPlanProductionRepository.findAll().stream()
-                .filter(plan -> !plan.getPlanDate().isBefore(today) && !plan.getPlanDate().isAfter(plannedPlanDate))
+        Integer totalJarsFromTodayToCheckDate = existingPlans.stream()
+                .filter(plan -> !plan.getPlanDate().isBefore(today) && !plan.getPlanDate().isAfter(checkUntilDate))
                 .mapToInt(plan -> plan.getSmallJamJars() + plan.getMediumJamJars() + plan.getLargeJamJars())
                 .sum();
 
-        Long countDaysBeforePlanDay = planProductionBeforePlannedPlanDate.stream()
-                .filter(plan -> plan.getPlanDate().isBefore(today))
-                .count();
+        if (!plannedPlanDate.isBefore(today) && !plannedPlanDate.isAfter(checkUntilDate)) {
+            totalJarsFromTodayToCheckDate += totalJamJarsForPlannedDay;
+        }
 
-        Long maxDeliveryCapacityBeforePlanDay = countDaysBeforePlanDay * maxDeliveryCapacityPerDay;
+        long daysInRange = Duration.between(today.atStartOfDay(), checkUntilDate.atStartOfDay()).toDays() + 1;
+        long maxCapacityInRange = daysInRange * maxDeliveryCapacityPerDay;
 
-        long howManyPlaceWeHave = maxDeliveryCapacityBeforePlanDay - existingSumJarsBeforePlanDay;
-
-        long more = howManyPlaceWeHave - moreThanMaxDeliveryCapacityPerDay;
-
-
-        if (totalJamJarsForPlannedDay > maxDeliveryCapacityPerDay) {
-            if (moreThanMaxDeliveryCapacityPerDay > howManyPlaceWeHave) {
-                throw new ProductionException("przekraczajaca zdolnośc transportowa. Mamy mejsce tylko na " + more);
-            }
-            throw new ProductionException("przekraczajaca zdolnośc transportowa. Mozna przelogyc na poprzedni dni");
+        if (totalJarsFromTodayToCheckDate > maxCapacityInRange) {
+            throw new ProductionException("Przekraczajaca zdolnośc transportowa na period z " + today + " po " + checkUntilDate + ".");
         }
     }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImpl.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImpl.java
@@ -106,6 +106,7 @@ public class JamPlanProductionServiceImpl implements JamPlanProductionService {
 
         long more = howManyPlaceWeHave - moreThanMaxDeliveryCapacityPerDay;
 
+
         if (totalJamJarsForPlannedDay > maxDeliveryCapacityPerDay) {
             if (moreThanMaxDeliveryCapacityPerDay > howManyPlaceWeHave) {
                 throw new ProductionException("przekraczajaca zdolnośc transportowa. Mamy mejsce tylko na " + more);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,3 +13,6 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+max-delivery-capacity:
+  maxDeliveryCapacity: 15 000

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,4 +15,4 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
 max-delivery-capacity:
-  maxDeliveryCapacity: 15 000
+  maxDeliveryCapacity: 15000

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,5 +14,5 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
-max-delivery-capacity:
+limits:
   maxDeliveryCapacity: 15000

--- a/src/test/java/pl/akademiaspecjalistowit/jamfactory/configuration/EmbeddedPostgresConfiguration.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jamfactory/configuration/EmbeddedPostgresConfiguration.java
@@ -32,8 +32,9 @@ public class EmbeddedPostgresConfiguration {
     }
 
     @Bean
-    public JamPlanProductionService jamPlanProductionService(JamPlanProductionRepository jamPlanProductionRepository, JamsMapper jamsMapper) {
-        return new JamPlanProductionServiceImpl(jamPlanProductionRepository, jamsMapper);
+    public JamPlanProductionService jamPlanProductionService(JamPlanProductionRepository jamPlanProductionRepository,
+                                                             JamsMapper jamsMapper, ApiProperties apiProperties) {
+        return new JamPlanProductionServiceImpl(jamPlanProductionRepository, jamsMapper, apiProperties);
     }
 
     @Bean

--- a/src/test/java/pl/akademiaspecjalistowit/jamfactory/configuration/EmbeddedPostgresConfiguration.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jamfactory/configuration/EmbeddedPostgresConfiguration.java
@@ -38,7 +38,7 @@ public class EmbeddedPostgresConfiguration {
     }
 
     @Bean
-    public JamsMapper jamsMapper(){
+    public JamsMapper jamsMapper() {
         return new JamsMapper();
     }
 
@@ -50,5 +50,10 @@ public class EmbeddedPostgresConfiguration {
             }
             embeddedPostgres.close();
         }
+    }
+
+    @Bean
+    public ApiProperties apiProperties() {
+        return new ApiProperties();
     }
 }

--- a/src/test/java/pl/akademiaspecjalistowit/jamfactory/configuration/EmbeddedPostgresConfiguration.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jamfactory/configuration/EmbeddedPostgresConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.testcontainers.utility.DockerImageName;
-import pl.akademiaspecjalistowit.jamfactory.JamPlanProductionEntity;
+import pl.akademiaspecjalistowit.jamfactory.entity.JamPlanProductionEntity;
 import pl.akademiaspecjalistowit.jamfactory.mapper.JamsMapper;
 import pl.akademiaspecjalistowit.jamfactory.repositories.JamPlanProductionRepository;
 import pl.akademiaspecjalistowit.jamfactory.service.JamPlanProductionService;

--- a/src/test/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImplTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImplTest.java
@@ -2,22 +2,23 @@ package pl.akademiaspecjalistowit.jamfactory.service;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import pl.akademiaspecjalistowit.jamfactory.entity.JamPlanProductionEntity;
 import pl.akademiaspecjalistowit.jamfactory.configuration.EmbeddedPostgresConfiguration;
 import pl.akademiaspecjalistowit.jamfactory.dto.JamPlanProductionRequestDto;
-import pl.akademiaspecjalistowit.jamfactory.mapper.JamsMapper;
+import pl.akademiaspecjalistowit.jamfactory.entity.JamPlanProductionEntity;
+import pl.akademiaspecjalistowit.jamfactory.exception.ProductionException;
 import pl.akademiaspecjalistowit.jamfactory.repositories.JamPlanProductionRepository;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.jar.JarException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
 @ExtendWith(EmbeddedPostgresConfiguration.EmbeddedPostgresExtension.class)
@@ -26,9 +27,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ActiveProfiles("test")
 class JamPlanProductionServiceImplTest {
 
-    private final LocalDate CORRECT_PLAN_DATE = LocalDate.of(2024, 9, 29);
+    private final LocalDate CORRECT_PLAN_DATE = LocalDate.now();
     private final Integer CORRECT_QUANTITY_JAM_JARS = 100;
     private final Integer INCORRECT_QUANTITY_JAM_JARS = -100;
+    private final Integer LARGE_QUANTITY_JAM_JARS = 20000;
 
     @Autowired
     private JamPlanProductionService jamPlanProductionService;
@@ -36,13 +38,12 @@ class JamPlanProductionServiceImplTest {
     @Autowired
     private JamPlanProductionRepository jamPlanProductionRepository;
 
-    @Autowired
-    private JamsMapper jamsMapper;
-
     @Test
-    void should_create_product_plan() throws JarException {
+    void should_create_product_plan() {
         //GIVEN
-        JamPlanProductionRequestDto jamPlanProductionRequestDto = new JamPlanProductionRequestDto(CORRECT_PLAN_DATE, CORRECT_QUANTITY_JAM_JARS, CORRECT_QUANTITY_JAM_JARS, CORRECT_QUANTITY_JAM_JARS);
+        JamPlanProductionRequestDto jamPlanProductionRequestDto = new JamPlanProductionRequestDto(CORRECT_PLAN_DATE,
+                CORRECT_QUANTITY_JAM_JARS, CORRECT_QUANTITY_JAM_JARS, CORRECT_QUANTITY_JAM_JARS);
+
         jamPlanProductionService.addProductionPlan(jamPlanProductionRequestDto);
 
         //WHEN
@@ -51,5 +52,42 @@ class JamPlanProductionServiceImplTest {
         //THEN
         assertThat(all).isNotNull();
         assertThat(all.size()).isEqualTo(1);
+        assertThat(all.get(0).getPlanDate()).isEqualTo(CORRECT_PLAN_DATE);
+        assertThat(all.get(0).getSmallJamJars()).isEqualTo(CORRECT_QUANTITY_JAM_JARS);
+        assertThat(all.get(0).getMediumJamJars()).isEqualTo(CORRECT_QUANTITY_JAM_JARS);
+        assertThat(all.get(0).getLargeJamJars()).isEqualTo(CORRECT_QUANTITY_JAM_JARS);
+    }
+
+    @Test
+    void should_throw_exception_when_invalid_capacity() {
+        //GIVEN
+        JamPlanProductionRequestDto jamPlanProductionRequestDto = new JamPlanProductionRequestDto(CORRECT_PLAN_DATE,
+                LARGE_QUANTITY_JAM_JARS, LARGE_QUANTITY_JAM_JARS, LARGE_QUANTITY_JAM_JARS);
+
+        //WHEN
+        Executable e = () -> jamPlanProductionService.addProductionPlan(jamPlanProductionRequestDto);
+
+        //THEN
+        assertThrows(ProductionException.class, e);
+    }
+
+    @Test
+    void should_throw_exception_with_add_new_plan_when_capacity_was_full() {
+        //GIVEN
+        LocalDate plan_date = LocalDate.now().plusDays(1);
+        Integer jars = 10000;
+        JamPlanProductionRequestDto jamPlanProductionRequestDto = new JamPlanProductionRequestDto(plan_date,
+                jars, jars, jars);
+
+        jamPlanProductionService.addProductionPlan(jamPlanProductionRequestDto);
+
+        JamPlanProductionRequestDto jamPlanProductionRequestDto2 = new JamPlanProductionRequestDto(CORRECT_PLAN_DATE,
+                LARGE_QUANTITY_JAM_JARS, LARGE_QUANTITY_JAM_JARS, LARGE_QUANTITY_JAM_JARS);
+
+        //WHEN
+        Executable e = () -> jamPlanProductionService.addProductionPlan(jamPlanProductionRequestDto);
+
+        //THEN
+        assertThrows(ProductionException.class, e);
     }
 }

--- a/src/test/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImplTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImplTest.java
@@ -7,7 +7,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import pl.akademiaspecjalistowit.jamfactory.JamPlanProductionEntity;
+import pl.akademiaspecjalistowit.jamfactory.entity.JamPlanProductionEntity;
 import pl.akademiaspecjalistowit.jamfactory.configuration.EmbeddedPostgresConfiguration;
 import pl.akademiaspecjalistowit.jamfactory.dto.JamPlanProductionRequestDto;
 import pl.akademiaspecjalistowit.jamfactory.mapper.JamsMapper;
@@ -15,7 +15,6 @@ import pl.akademiaspecjalistowit.jamfactory.repositories.JamPlanProductionReposi
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.UUID;
 import java.util.jar.JarException;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImplTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImplTest.java
@@ -94,7 +94,7 @@ class JamPlanProductionServiceImplTest {
     }
 
     @Test
-    void should_throw_exception_with_add_new_plan_when_capacity_was_full2() {
+    void should_throw_exception_with_add_new_plan_when_capacity_was_full() {
         //GIVEN
         LocalDate plan_date = LocalDate.now().plusDays(1);
         LocalDate plan_date2 = LocalDate.now();

--- a/src/test/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImplTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImplTest.java
@@ -1,5 +1,6 @@
 package pl.akademiaspecjalistowit.jamfactory.service;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
@@ -38,6 +39,11 @@ class JamPlanProductionServiceImplTest {
     @Autowired
     private JamPlanProductionRepository jamPlanProductionRepository;
 
+    @AfterEach
+    void tearDown() {
+        jamPlanProductionRepository.deleteAll();
+    }
+
     @Test
     void should_create_product_plan() {
         //GIVEN
@@ -72,20 +78,42 @@ class JamPlanProductionServiceImplTest {
     }
 
     @Test
-    void should_throw_exception_with_add_new_plan_when_capacity_was_full() {
+    void should_throw_exception_with_incorect_capacity() {
         //GIVEN
         LocalDate plan_date = LocalDate.now().plusDays(1);
-        Integer jars = 10000;
+        Integer jars = 1000;
+
         JamPlanProductionRequestDto jamPlanProductionRequestDto = new JamPlanProductionRequestDto(plan_date,
                 jars, jars, jars);
 
-        jamPlanProductionService.addProductionPlan(jamPlanProductionRequestDto);
-
-        JamPlanProductionRequestDto jamPlanProductionRequestDto2 = new JamPlanProductionRequestDto(CORRECT_PLAN_DATE,
-                LARGE_QUANTITY_JAM_JARS, LARGE_QUANTITY_JAM_JARS, LARGE_QUANTITY_JAM_JARS);
-
         //WHEN
         Executable e = () -> jamPlanProductionService.addProductionPlan(jamPlanProductionRequestDto);
+
+        //THEN
+        assertThrows(ProductionException.class, e);
+    }
+
+    @Test
+    void should_throw_exception_with_add_new_plan_when_capacity_was_full2() {
+        //GIVEN
+        LocalDate plan_date = LocalDate.now().plusDays(1);
+        LocalDate plan_date2 = LocalDate.now();
+
+        Integer jars_s = 5000;
+        Integer jars_m = 5000;
+        Integer jars_l = 5000;
+        Integer jars = 7000;
+
+        JamPlanProductionRequestDto jamPlanProductionRequestDto = new JamPlanProductionRequestDto(plan_date,
+                jars_s, jars_m, jars);
+
+        jamPlanProductionService.addProductionPlan(jamPlanProductionRequestDto);
+
+        JamPlanProductionRequestDto jamPlanProductionRequestDto2 = new JamPlanProductionRequestDto(plan_date2,
+                jars_s, jars_m, jars_l);
+
+        //WHEN
+        Executable e = () -> jamPlanProductionService.addProductionPlan(jamPlanProductionRequestDto2);
 
         //THEN
         assertThrows(ProductionException.class, e);


### PR DESCRIPTION
- Dodanie nowego Planu produkcyjnego jest możliwe jeżeli:
- w ramach jednego dnia ilość dostarczonych słoików (wynikająca z istnejącego dziennego planu produkcyjnych) nie można być większa niż X.
- (Ilość dni x maxDeliveryCapacity - aktualne plany produkcyjne) >= nowy plan
- X jest elementem parametryzowanym w application.yaml
- MaxDeliveryCapacity: 15 000