### PR TITLE
[011] Dodanie planu produkcyjnego - uwzględnienie możliwości produkcy…

### DIFF
--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/JamPlanProductionEntity.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/JamPlanProductionEntity.java
@@ -33,10 +33,24 @@ public class JamPlanProductionEntity {
     private Integer largeJamJars;
 
     public JamPlanProductionEntity(LocalDate planDate, Integer smallJamJars, Integer mediumJamJars, Integer largeJamJars) {
+        this.smallJamJars = smallJamJars == null ? 0:smallJamJars;
+        this.largeJamJars = largeJamJars == null ? 0:largeJamJars;
+        this.mediumJamJars = mediumJamJars == null ? 0:mediumJamJars;
         this.planId = UUID.randomUUID();
         this.planDate = planDate;
-        this.smallJamJars = smallJamJars;
-        this.mediumJamJars = mediumJamJars;
-        this.largeJamJars = largeJamJars;
+    }
+    public double getTotalJamWeight(){
+        return (JarSizes.LARGE.value * largeJamJars) + (JarSizes.MEDIUM.value * mediumJamJars) + (JarSizes.SMALL.value * smallJamJars);
+    }
+    private enum JarSizes{
+
+        LARGE(1),
+        MEDIUM(0.5),
+        SMALL(0.25);
+        private final double value;
+
+        JarSizes(double value) {
+            this.value = value;
+        }
     }
 }

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/configuration/ApiProperties.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/configuration/ApiProperties.java
@@ -1,0 +1,15 @@
+package pl.akademiaspecjalistowit.jamfactory.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "limits")
+@Component
+public class ApiProperties {
+    private Integer maxDeliveryCapacity;
+    private Integer maxProductionLimit;
+}

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryController.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryController.java
@@ -1,5 +1,6 @@
 package pl.akademiaspecjalistowit.jamfactory.controller;
 
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +18,7 @@ public class JamFactoryController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/product-plan")
-    public UUID addProductionPlan(@RequestBody JamPlanProductionRequestDto jamPlanProductionRequestDto) {
+    public UUID addProductionPlan( @RequestBody JamPlanProductionRequestDto jamPlanProductionRequestDto) {
         return jamPlanProductionService.addProductionPlan(jamPlanProductionRequestDto);
     }
 

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/repositories/JamPlanProductionRepository.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/repositories/JamPlanProductionRepository.java
@@ -4,6 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import pl.akademiaspecjalistowit.jamfactory.JamPlanProductionEntity;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Repository
 public interface JamPlanProductionRepository extends JpaRepository<JamPlanProductionEntity, Long> {
+   List<JamPlanProductionEntity> findAllByPlanDate(LocalDate now);
 }

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImpl.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/service/JamPlanProductionServiceImpl.java
@@ -3,22 +3,49 @@ package pl.akademiaspecjalistowit.jamfactory.service;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import pl.akademiaspecjalistowit.jamfactory.JamPlanProductionEntity;
+import pl.akademiaspecjalistowit.jamfactory.configuration.ApiProperties;
 import pl.akademiaspecjalistowit.jamfactory.dto.JamPlanProductionRequestDto;
+import pl.akademiaspecjalistowit.jamfactory.exception.ProductionException;
 import pl.akademiaspecjalistowit.jamfactory.mapper.JamsMapper;
 import pl.akademiaspecjalistowit.jamfactory.repositories.JamPlanProductionRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 @AllArgsConstructor
 @Service
+
 public class JamPlanProductionServiceImpl implements JamPlanProductionService {
     private final JamPlanProductionRepository jamPlanProductionRepository;
     private final JamsMapper jamsMapper;
+    private final ApiProperties apiProperties;
 
     @Override
     public UUID addProductionPlan(JamPlanProductionRequestDto jamPlanProductionRequestDto) {
         JamPlanProductionEntity entity = jamsMapper.toEntity(jamPlanProductionRequestDto);
+        validateAddingNewProductionPlanPossibility(entity);
         jamPlanProductionRepository.save(entity);
         return entity.getPlanId();
+    }
+
+    private void validateAddingNewProductionPlanPossibility(JamPlanProductionEntity entity) {
+        List<JamPlanProductionEntity> allByDate = jamPlanProductionRepository.findAllByPlanDate(entity.getPlanDate());
+
+        double totalActualSum = allByDate.stream()
+                .mapToDouble(JamPlanProductionEntity::getTotalJamWeight)
+                .sum();
+
+        double newTotal = totalActualSum + entity.getTotalJamWeight();
+        double maxProductionLimit = apiProperties.getMaxProductionLimit();
+
+        System.out.println("Total weight before adding: " + totalActualSum);
+        System.out.println("New plan weight: " + entity.getTotalJamWeight());
+        System.out.println("Total weight after adding: " + newTotal);
+
+        if (newTotal > maxProductionLimit) {
+            double exceededLimit = newTotal - maxProductionLimit;
+            System.out.println("Exceeded limit by: " + exceededLimit + " Kg");
+            throw new ProductionException("Przekroczono limit produkcyjny o " + exceededLimit + " Kg");
+        }
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,7 +1,6 @@
 spring:
   application:
     name: jamFactory
-
   datasource:
     url: jdbc:postgresql://localhost:5440/jam_factory
     username: postgres
@@ -13,3 +12,5 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+limits:
+  maxProductionLimit: 2000

--- a/src/test/java/pl/akademiaspecjalistowit/jamfactory/JamPlanProductionEntityTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jamfactory/JamPlanProductionEntityTest.java
@@ -1,0 +1,63 @@
+package pl.akademiaspecjalistowit.jamfactory;
+
+import org.junit.jupiter.api.Test;
+import pl.akademiaspecjalistowit.jamfactory.controller.JamFactoryController;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class JamPlanProductionEntityTest {
+
+
+    private JamFactoryController jamPlanProductionServiceImpl;
+
+    @Test
+    void ShouldConvertAllJamJarsToWeightCorrectly() {
+        //given
+        JamPlanProductionEntity jamPlanProductionEntity = new JamPlanProductionEntity(LocalDate.now(), 10, 10, 10);
+
+        //when
+        double totalJamWeight = jamPlanProductionEntity.getTotalJamWeight();
+
+        //then
+        assertThat(totalJamWeight).isEqualTo(17.5);
+    }
+
+    @Test
+    void ShouldConvertAllJamJarsToWeightIgnoreMissingSmallJamJars() {
+        //given
+        JamPlanProductionEntity jamPlanProductionEntity = new JamPlanProductionEntity(LocalDate.now(), null, 10, 10);
+
+        //when
+        double totalJamWeight = jamPlanProductionEntity.getTotalJamWeight();
+
+        //then
+        assertThat(totalJamWeight).isEqualTo(15);
+    }
+
+    @Test
+    void ShouldConvertAllJamJarsToWeightIgnoreMissingMeidumJamJars() {
+        //given
+        JamPlanProductionEntity jamPlanProductionEntity = new JamPlanProductionEntity(LocalDate.now(), 10, null, 10);
+
+        //when
+        double totalJamWeight = jamPlanProductionEntity.getTotalJamWeight();
+
+        //then
+        assertThat(totalJamWeight).isEqualTo(12.5);
+    }
+
+    @Test
+    void ShouldConvertAllJamJarsToWeightIgnoreMissingLargeJamJars() {
+        //given
+        JamPlanProductionEntity jamPlanProductionEntity = new JamPlanProductionEntity(LocalDate.now(), 10, 10, null);
+
+        //when
+        double totalJamWeight = jamPlanProductionEntity.getTotalJamWeight();
+
+        //then
+        assertThat(totalJamWeight).isEqualTo(7.5);
+    }
+}

--- a/src/test/java/pl/akademiaspecjalistowit/jamfactory/configuration/EmbeddedPostgresConfiguration.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jamfactory/configuration/EmbeddedPostgresConfiguration.java
@@ -32,12 +32,17 @@ public class EmbeddedPostgresConfiguration {
     }
 
     @Bean
-    public JamPlanProductionService jamPlanProductionService(JamPlanProductionRepository jamPlanProductionRepository, JamsMapper jamsMapper) {
-        return new JamPlanProductionServiceImpl(jamPlanProductionRepository, jamsMapper);
+    public JamPlanProductionService jamPlanProductionService(JamPlanProductionRepository jamPlanProductionRepository, JamsMapper jamsMapper, ApiProperties apiProperties) {
+        return new JamPlanProductionServiceImpl(jamPlanProductionRepository, jamsMapper, apiProperties);
     }
 
     @Bean
-    public JamsMapper jamsMapper(){
+    public ApiProperties apiProperties() {
+        return new ApiProperties();
+    }
+
+    @Bean
+    public JamsMapper jamsMapper() {
         return new JamsMapper();
     }
 


### PR DESCRIPTION
…jnych dżemu fabryki

Kryteria akceptacji:

Plan produkcyjny nie może zostać dodany, jeżeli:

Nowy plan Produkcyjny + istniejące plany produkcyjne przeliczone na KG przekraczają zdolność produkcyjną fabryki dżemu na wskazany dzień w ramach jednego dnia.

Przykład:
Pracownik tworzy nowy plan produkcyjny dnia 21.08 na 24.08 na łączną ilość 1000kg dżemu, a wszystkie złożone plany produkcyjne 24.08 zajmują 1900kg. Zakładając że dziene max produkcyjne wynosi 2000kg, to request zostaje odrzucony, bo przekraczamy o 100kg. W przyadku odrzucenia planu odpowiadamy HTTP 400

{
  reason: "Przekroczono limit produkcyjny o 100kg"
  code: "JAM_DAILY_PRDUCTION_LIMIT_EXCEEDED"
}

Nowy plan produkcyjny sam przekracza dzienny limit produkcji w KG

Limit produkcyjny jest wartością parametryzowaną w application.yaml, ustawioną na 2000kg.