### PR TITLE
JamPlanProductionService - segragacja wyjątkow w komunikacji z JarService

### DIFF
--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryControllerAdvice.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/controller/JamFactoryControllerAdvice.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import pl.akademiaspecjalistowit.jamfactory.exception.BusinessException;
+import pl.akademiaspecjalistowit.jamfactory.exception.JamPlanProductionServiceException;
 import pl.akademiaspecjalistowit.jamfactory.exception.JarFactoryHttpClientException;
 import pl.akademiaspecjalistowit.jamfactory.exception.ProductionException;
 
@@ -32,6 +33,12 @@ public class JamFactoryControllerAdvice {
     public ResponseEntity<RejectResponse> handleJarFactoryHttpClientException(JarFactoryHttpClientException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(new RejectResponse(e.getMessage(), ErrorCode.INSUFFICIENT_JARS));
+    }
+
+    @ExceptionHandler(JamPlanProductionServiceException.class)
+    public ResponseEntity<RejectResponse> handleProductionException(JamPlanProductionServiceException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new RejectResponse(e.getMessage(), ErrorCode.JAM_PRODUCTION_LIMIT_EXCEEDED));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/pl/akademiaspecjalistowit/jamfactory/exception/JamPlanProductionServiceException.java
+++ b/src/main/java/pl/akademiaspecjalistowit/jamfactory/exception/JamPlanProductionServiceException.java
@@ -1,0 +1,12 @@
+package pl.akademiaspecjalistowit.jamfactory.exception;
+
+public class JamPlanProductionServiceException extends RuntimeException{
+
+    public JamPlanProductionServiceException(String message) {
+        super(message);
+    }
+
+    public JamPlanProductionServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
JamPlanProductionService powinien otrzymywać JarService Exception i na niego reagować (przepakować w JamPlanProductionServiceException) a nie JarHttp…Exception.