### PR TITLE
JamPlanProductionEntity - 1. W pierwszej kolejności powinny zostać wypełnione duże słoiki w planie produkcyjnym

### DIFF
--- a/src/test/java/pl/akademiaspecjalistowit/jamfactory/JamPlanProductionEntityFillProductionPlanTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jamfactory/JamPlanProductionEntityFillProductionPlanTest.java
@@ -36,4 +36,20 @@ class JamPlanProductionEntityFillProductionPlanTest {
         assertThat(jamPlanProductionEntityFilled.getTotalJamWeight()).isCloseTo(2000d, Offset.offset(0.24));
     }
 
+    @Test
+    void should_fill_JamPlanProductionEntity_firstly_large_jars() {
+        //given
+        JamPlanProductionEntity jamPlanProductionEntity = new JamPlanProductionEntity(LocalDate.now(), 2000);
+        JamJars jamJars = new JamJars(1000, 1000, 2000);
+
+        //when
+        JamPlanProductionEntity jamPlanProductionEntityFilled = jamPlanProductionEntity.fillProductionPlan(jamJars);
+
+        //then
+        assertThat(jamPlanProductionEntityFilled.getTotalJamWeight()).isEqualTo(2000);
+        assertThat(jamPlanProductionEntityFilled.getLargeJamJars()).isEqualTo(2000);
+        assertThat(jamPlanProductionEntityFilled.getMediumJamJars()).isEqualTo(0);
+        assertThat(jamPlanProductionEntityFilled.getSmallJamJars()).isEqualTo(0);
+    }
+
 }


### PR DESCRIPTION
https://trello.com/c/iyoxpkK6/33-jamplanproductionentity-1-w-pierwszej-kolejno%C5%9Bci-powinny-zosta%C4%87-wype%C5%82nione-du%C5%BCe-s%C5%82oiki-w-planie-produkcyjnym