### PR TITLE
JamPlanProductionEntity - 2. Kiedy ilość dużych będzie wypełniona w następnej kolejności powinny zostać wypełnione średnie słoiki w planie produkcyjnym

### DIFF
--- a/src/test/java/pl/akademiaspecjalistowit/jamfactory/JamPlanProductionEntityFillProductionPlanTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jamfactory/JamPlanProductionEntityFillProductionPlanTest.java
@@ -52,4 +52,20 @@ class JamPlanProductionEntityFillProductionPlanTest {
         assertThat(jamPlanProductionEntityFilled.getSmallJamJars()).isEqualTo(0);
     }
 
+    @Test
+    void should_fill_JamPlanProductionEntity_firstly_large_jars_secondly_medium_jars() {
+        //given
+        JamPlanProductionEntity jamPlanProductionEntity = new JamPlanProductionEntity(LocalDate.now(), 2000);
+        JamJars jamJars = new JamJars(1000, 2000, 1500);
+
+        //when
+        JamPlanProductionEntity jamPlanProductionEntityFilled = jamPlanProductionEntity.fillProductionPlan(jamJars);
+
+        //then
+        assertThat(jamPlanProductionEntityFilled.getTotalJamWeight()).isEqualTo(2000);
+        assertThat(jamPlanProductionEntityFilled.getLargeJamJars()).isEqualTo(1500);
+        assertThat(jamPlanProductionEntityFilled.getMediumJamJars()).isEqualTo(1000);
+        assertThat(jamPlanProductionEntityFilled.getSmallJamJars()).isEqualTo(0);
+    }
+
 }

--- a/src/test/java/pl/akademiaspecjalistowit/jamfactory/JamPlanProductionEntityFillProductionPlanTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jamfactory/JamPlanProductionEntityFillProductionPlanTest.java
@@ -36,4 +36,20 @@ class JamPlanProductionEntityFillProductionPlanTest {
         assertThat(jamPlanProductionEntityFilled.getTotalJamWeight()).isCloseTo(2000d, Offset.offset(0.24));
     }
 
+    @Test
+    void should_fill_JamPlanProductionEntity_firstly_large_jars() {
+        //given
+        JamPlanProductionEntity jamPlanProductionEntity = new JamPlanProductionEntity(LocalDate.now(), 2000);
+        JamJars jamJars = new JamJars(1000, 1000, 2000);
+
+        //when
+        JamPlanProductionEntity jamPlanProductionEntityFilled = jamPlanProductionEntity.fillProductionPlan(jamJars);
+
+        //then
+        assertThat(jamPlanProductionEntityFilled.getTotalJamWeight()).isEqualTo(2000);
+        assertThat(jamPlanProductionEntityFilled.getLargeJamJars()).isEqualTo(2000);
+        assertThat(jamPlanProductionEntityFilled.getMediumJamJars()).isEqualTo(0);
+        assertThat(jamPlanProductionEntityFilled.getSmallJamJars()).isEqualTo(0);
+    }
+
 }


### PR DESCRIPTION
https://trello.com/c/tQM8zpty/34-jamplanproductionentity-2-kiedy-ilo%C5%9B%C4%87-du%C5%BCych-b%C4%99dzie-wype%C5%82niona-w-nast%C4%99pnej-kolejno%C5%9Bci-powinny-zosta%C4%87-wype%C5%82nione-%C5%9Brednie-s%C5%82oiki-w