### PR TITLE
Test jam plan production entity male sloiki w planie produkcyjnym

### DIFF
--- a/src/test/java/pl/akademiaspecjalistowit/jamfactory/JamPlanProductionEntityFillProductionPlanTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jamfactory/JamPlanProductionEntityFillProductionPlanTest.java
@@ -1,12 +1,13 @@
 package pl.akademiaspecjalistowit.jamfactory;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.time.LocalDate;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
-import pl.akademiaspecjalistowit.jamfactory.model.JamJars;
 import pl.akademiaspecjalistowit.jamfactory.entity.JamPlanProductionEntity;
+import pl.akademiaspecjalistowit.jamfactory.model.JamJars;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class JamPlanProductionEntityFillProductionPlanTest {
 
@@ -68,4 +69,19 @@ class JamPlanProductionEntityFillProductionPlanTest {
         assertThat(jamPlanProductionEntityFilled.getSmallJamJars()).isEqualTo(0);
     }
 
+    @Test
+    void should_fill_JamPlanProductionEntity_firstly_large_jars_secondly_medium_jars_and_thirst_small_jars() {
+        //given
+        JamPlanProductionEntity jamPlanProductionEntity = new JamPlanProductionEntity(LocalDate.now(), 2000);
+        JamJars jamJars = new JamJars(7000, 500, 500);
+
+        //when
+        JamPlanProductionEntity jamPlanProductionEntityFilled = jamPlanProductionEntity.fillProductionPlan(jamJars);
+
+        //then
+        assertThat(jamPlanProductionEntityFilled.getTotalJamWeight()).isEqualTo(2000);
+        assertThat(jamPlanProductionEntityFilled.getLargeJamJars()).isEqualTo(500);
+        assertThat(jamPlanProductionEntityFilled.getMediumJamJars()).isEqualTo(500);
+        assertThat(jamPlanProductionEntityFilled.getSmallJamJars()).isEqualTo(5000);
+    }
 }

--- a/src/test/java/pl/akademiaspecjalistowit/jamfactory/JamPlanProductionEntityFillProductionPlanTest.java
+++ b/src/test/java/pl/akademiaspecjalistowit/jamfactory/JamPlanProductionEntityFillProductionPlanTest.java
@@ -70,7 +70,7 @@ class JamPlanProductionEntityFillProductionPlanTest {
     }
 
     @Test
-    void should_fill_JamPlanProductionEntity_firstly_large_jars_secondly_medium_jars_and_thirst_small_jars() {
+    void should_fill_JamPlanProductionEntity_firstly_large_jars_secondly_medium_jars_and_thirdly_small_jars() {
         //given
         JamPlanProductionEntity jamPlanProductionEntity = new JamPlanProductionEntity(LocalDate.now(), 2000);
         JamJars jamJars = new JamJars(7000, 500, 500);


### PR DESCRIPTION
JamPlanProductionEntity - 3. Po uzupełnieniu dużych i średnich słoików kiedy zostanie jeszcze nierozdzielony dżem powinny zostać wypełnione małe słoiki w planie produkcyjnym